### PR TITLE
Fix postData

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,11 @@ PATH
   remote: .
   specs:
     akita-har_logger (0.2.1)
-      json (~> 2.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.4.4)
-    json (2.5.1)
     rake (13.0.3)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)

--- a/akita-har_logger.gemspec
+++ b/akita-har_logger.gemspec
@@ -31,7 +31,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'json', '~> 2.3'
-
   spec.add_development_dependency 'rspec', '~> 3.10'
 end

--- a/lib/akita/har_logger/har_entry.rb
+++ b/lib/akita/har_logger/har_entry.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
 require_relative 'http_request'
 require_relative 'http_response'
 

--- a/lib/akita/har_logger/har_utils.rb
+++ b/lib/akita/har_logger/har_utils.rb
@@ -14,6 +14,17 @@ module Akita
           })
         }
       end
+
+      # Determines whether all values in a Hash are strings.
+      def self.allValuesAreStrings(hash)
+        hash.each do |_, value|
+          if !(value.is_a? String) then
+            return false
+          end
+        end
+
+        return true
+      end
     end
   end
 end

--- a/lib/akita/har_logger/http_request.rb
+++ b/lib/akita/har_logger/http_request.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
 require_relative 'har_utils'
 
 module Akita

--- a/lib/akita/har_logger/http_request.rb
+++ b/lib/akita/har_logger/http_request.rb
@@ -81,12 +81,21 @@ module Akita
           # populate 'text.
           req = Rack::Request.new env
           if env['CONTENT_TYPE'] == 'application/x-www-form-urlencoded' then
-            # Decoded parameters can be found as a map in req.params. Convert
-            # this map into an array.
+            # Decoded parameters can be found as a map in req.params.
             #
-            # XXX Spec has space for files, but are file uploads ever
-            # URL-encoded?
-            result[:params] = HarUtils.hashToList req.params
+            # Requests originating from specs can be malformed: the values in
+            # req.params are not necessarily strings. Encode all of req.params
+            # in JSON and pretend the content type was "application/json".
+            if HarUtils.allValuesAreStrings req.params then
+              # Convert req.params into an array.
+              #
+              # XXX Spec has space for files, but are file uploads ever
+              # URL-encoded?
+              result[:params] = HarUtils.hashToList req.params
+            else
+              result[:mimeType] = 'application/json'
+              result[:text] = req.params.to_json
+            end
           else
             result[:text] = req.body.string
           end

--- a/lib/akita/har_logger/http_response.rb
+++ b/lib/akita/har_logger/http_response.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
 require_relative 'har_utils'
 
 module Akita

--- a/lib/akita/har_logger/version.rb
+++ b/lib/akita/har_logger/version.rb
@@ -2,6 +2,6 @@
 
 module Akita
   module HarLogger
-    VERSION = "0.2.1"
+    VERSION = "0.2.2"
   end
 end

--- a/lib/akita/har_logger/writer_thread.rb
+++ b/lib/akita/har_logger/writer_thread.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'json'
-
 module Akita
   module HarLogger
     # A thread that consumes HarEntry objects from a queue and writes them to a


### PR DESCRIPTION
Requests originating from specs can be malformed: the values in Rails's environment are not necessarily strings, even though the content type is purported to be "application/x-www-form-urlencoded". If we find a non-string value in any parameter, work around this by converting the post data to "application/json".

Also removed explicit `json` dependency, based on user feedback.

Bumped to v0.2.2.