### PR TITLE
Account for Rack's broken use of string encodings

### DIFF
--- a/lib/akita/har_logger/har_utils.rb
+++ b/lib/akita/har_logger/har_utils.rb
@@ -4,11 +4,10 @@ module Akita
   module HarLogger
     class HarUtils
       # Rack apparently uses 8-bit ASCII for everything, even when the string
-      # is not 8-bit ASCII. This reinterprets the given string as the default
-      # external encoding and re-encodes into the default internal encoding.
+      # is not 8-bit ASCII. This reinterprets the given string as UTF-8.
       def self.fixEncoding(v)
         if v != nil then
-          v.encode(Encoding.default_internal, Encoding.default_external)
+          v.force_encoding(Encoding::UTF_8)
         else
           nil
         end

--- a/lib/akita/har_logger/har_utils.rb
+++ b/lib/akita/har_logger/har_utils.rb
@@ -3,11 +3,23 @@
 module Akita
   module HarLogger
     class HarUtils
+      # Rack apparently uses 8-bit ASCII for everything, even when the string
+      # is not 8-bit ASCII. This reinterprets the given string as the default
+      # external encoding and re-encodes into the default internal encoding.
+      def self.fixEncoding(v)
+        if v != nil then
+          v.encode(Encoding.default_internal, Encoding.default_external)
+        else
+          nil
+        end
+      end
+
       # Converts a Hash into a list of Hash objects. Each entry in the given
       # Hash will be represented in the output by a Hash object that maps
       # 'name' to the entry's key and 'value' to the entry's value.
       def self.hashToList(hash)
         hash.reduce([]) { |accum, (k, v)|
+
           accum.append({
             name: k,
             value: v,

--- a/lib/akita/har_logger/har_utils.rb
+++ b/lib/akita/har_logger/har_utils.rb
@@ -6,10 +6,10 @@ module Akita
       # Rack apparently uses 8-bit ASCII for everything, even when the string
       # is not 8-bit ASCII. This reinterprets the given string as UTF-8.
       def self.fixEncoding(v)
-        if v != nil then
-          v.force_encoding(Encoding::UTF_8)
+        if v == nil || v.encoding == Encoding::UTF_8 then
+          v
         else
-          nil
+          String.new(v).force_encoding(Encoding::UTF_8)
         end
       end
 
@@ -18,10 +18,9 @@ module Akita
       # 'name' to the entry's key and 'value' to the entry's value.
       def self.hashToList(hash)
         hash.reduce([]) { |accum, (k, v)|
-
           accum.append({
-            name: k,
-            value: v,
+            name: fixEncoding(k),
+            value: fixEncoding(v),
           })
         }
       end

--- a/lib/akita/har_logger/http_request.rb
+++ b/lib/akita/har_logger/http_request.rb
@@ -116,8 +116,8 @@ module Akita
             # Rack has been observed to use ASCII-8BIT encoding for the request
             # body when the request specifies UTF-8. Reinterpret the content
             # body according to what the request says it is, and re-encode into
-            # the default internal encoding.
-            result[:text] = req.body.string.encode(Encoding.default_internal,
+            # UTF-8.
+            result[:text] = req.body.string.encode(Encoding::UTF_8,
                 getPostDataCharSet(env))
           end
 

--- a/lib/akita/har_logger/http_request.rb
+++ b/lib/akita/har_logger/http_request.rb
@@ -11,7 +11,7 @@ module Akita
 
         @self = {
           method: getMethod(env),
-          url: req.url,
+          url: HarUtils.fixEncoding(req.url),
           httpVersion: getHttpVersion(env),
           cookies: getCookies(env),
           headers: getHeaders(env),
@@ -33,7 +33,7 @@ module Akita
 
       # Obtains the client's request method from an HTTP environment.
       def getMethod(env)
-        (Rack::Request.new env).request_method
+        HarUtils.fixEncoding (Rack::Request.new env).request_method
       end
 
       # Obtains the client-requested HTTP version from an HTTP environment.
@@ -41,7 +41,9 @@ module Akita
         # The environment doesn't have HTTP_VERSION when running with `rspec`;
         # assume HTTP/1.1 when this happens. We don't return nil, so we can
         # calculate the size of the headers.
-        env.key?('HTTP_VERSION') ? env['HTTP_VERSION'] : 'HTTP/1.1'
+        env.key?('HTTP_VERSION') ?
+          HarUtils.fixEncoding(env['HTTP_VERSION']) :
+          'HTTP/1.1'
       end
 
       # Builds a list of cookie objects from an HTTP environment.
@@ -71,13 +73,28 @@ module Akita
         HarUtils.hashToList paramMap
       end
 
+      # Obtains the character set of the posted data from an HTTP environment.
+      def getPostDataCharSet(env)
+        req = Rack::Request.new env
+        if req.content_charset != nil then
+          return req.content_charset
+        end
+
+        # RFC 2616 says that "text/*" defaults to ISO-8859-1.
+        if env['CONTENT_TYPE'].start_with?('text/') then
+          return Encoding::ISO_8859_1
+        end
+
+        Encoding.default_external
+      end
+
       # Obtains the posted data from an HTTP environment.
       def getPostData(env)
         if env.key?('CONTENT_TYPE') && env['CONTENT_TYPE'] then
           result = { mimeType: env['CONTENT_TYPE'] }
 
           # Populate 'params' if we have URL-encoded parameters. Otherwise,
-          # populate 'text.
+          # populate 'text'.
           req = Rack::Request.new env
           if env['CONTENT_TYPE'] == 'application/x-www-form-urlencoded' then
             # Decoded parameters can be found as a map in req.params.
@@ -96,7 +113,12 @@ module Akita
               result[:text] = req.params.to_json
             end
           else
-            result[:text] = req.body.string
+            # Rack has been observed to use ASCII-8BIT encoding for the request
+            # body when the request specifies UTF-8. Reinterpret the content
+            # body according to what the request says it is, and re-encode into
+            # the default internal encoding.
+            result[:text] = req.body.string.encode(Encoding.default_internal,
+                getPostDataCharSet(env))
           end
 
           result

--- a/lib/akita/har_logger/http_response.rb
+++ b/lib/akita/har_logger/http_response.rb
@@ -36,7 +36,9 @@ module Akita
         # The environment doesn't have HTTP_VERSION when running with `rspec`;
         # assume HTTP/1.1 when this happens. We don't return nil, so we can
         # calculate the size of the headers.
-        env.key?('HTTP_VERSION') ? env['HTTP_VERSION'] : 'HTTP/1.1'
+        env.key?('HTTP_VERSION') ?
+          HarUtils.fixEncoding(env['HTTP_VERSION']) :
+          'HTTP/1.1'
       end
 
       def getCookies(headers)

--- a/lib/akita/har_logger/version.rb
+++ b/lib/akita/har_logger/version.rb
@@ -2,6 +2,6 @@
 
 module Akita
   module HarLogger
-    VERSION = "0.2.2"
+    VERSION = "0.2.3"
   end
 end


### PR DESCRIPTION
Rack assigns 8-bit ASCII encoding to all strings in its request environment. This causes issues when these strings have characters with the 8th bit set and are converted to UTF-8 for output to the HAR file. Work around this by forcing all strings taken from the request environment to be UTF-8.

https://github.com/phusion/passenger/issues/1328

This bumps the version number to 0.2.3.