### PR TITLE
Follow-up to #5: also fix encodings in responses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    akita-har_logger (0.2.3)
+    akita-har_logger (0.2.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/akita/har_logger/har_utils.rb
+++ b/lib/akita/har_logger/har_utils.rb
@@ -4,9 +4,9 @@ module Akita
   module HarLogger
     class HarUtils
       # Rack apparently uses 8-bit ASCII for everything, even when the string
-      # is not 8-bit ASCII. This reinterprets the given string as UTF-8.
+      # is not 8-bit ASCII. This reinterprets 8-bit ASCII strings as UTF-8.
       def self.fixEncoding(v)
-        if v == nil || v.encoding == Encoding::UTF_8 then
+        if v == nil || v.encoding != Encoding::ASCII_8BIT then
           v
         else
           String.new(v).force_encoding(Encoding::UTF_8)

--- a/lib/akita/har_logger/http_response.rb
+++ b/lib/akita/har_logger/http_response.rb
@@ -25,7 +25,7 @@ module Akita
 
       # Obtains the status text corresponding to a status code.
       def getStatusText(status)
-        Rack::Utils::HTTP_STATUS_CODES[status]
+        HarUtils.fixEncoding(Rack::Utils::HTTP_STATUS_CODES[status])
       end
 
       # Obtains the HTTP version in the response.
@@ -65,8 +65,8 @@ module Akita
           if match then cookie_value = match[1] end
 
           result << {
-            name: cookie_name,
-            value: cookie_value,
+            name: HarUtils.fixEncoding(cookie_name),
+            value: HarUtils.fixEncoding(cookie_value),
           }
         }
 
@@ -79,14 +79,14 @@ module Akita
         text = +""
         body.each { |part|
           # XXX Figure out how to join together multi-part bodies.
-          text << part;
+          text << (HarUtils.fixEncoding part);
         }
 
         {
           size: getBodySize(body),
 
           # XXX What to use when no Content-Type is given?
-          mimeType: headers['Content-Type'],
+          mimeType: HarUtils.fixEncoding(headers['Content-Type']),
 
           text: text,
         }
@@ -95,7 +95,9 @@ module Akita
       def getRedirectUrl(headers)
         # Use the "Location" header if it exists. Otherwise, based on some HAR
         # examples found online, it looks like an empty string is used.
-        headers.key?('Location') ? headers['Location'] : ''
+        headers.key?('Location') ?
+          HarUtils.fixEncoding(headers['Location']) :
+          ''
       end
 
       def getHeadersSize(env, status, headers)

--- a/lib/akita/har_logger/version.rb
+++ b/lib/akita/har_logger/version.rb
@@ -2,6 +2,6 @@
 
 module Akita
   module HarLogger
-    VERSION = "0.2.3"
+    VERSION = "0.2.4"
   end
 end


### PR DESCRIPTION
Looks like Rack also gives us 8-bit ASCII strings when we log the response. Bumped to v0.2.4.