### PR TITLE
Log potential encoding issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    akita-har_logger (0.2.4)
+    akita-har_logger (0.2.5)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/akita/har_logger/version.rb
+++ b/lib/akita/har_logger/version.rb
@@ -2,6 +2,6 @@
 
 module Akita
   module HarLogger
-    VERSION = "0.2.4"
+    VERSION = "0.2.5"
   end
 end


### PR DESCRIPTION
Also gracefully handle any encoding issues in request bodies, while
logging a warning.

Bump to v0.2.5.