### PR TITLE
Ignore binary data in response bodies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    akita-har_logger (0.2.5)
+    akita-har_logger (0.2.6)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/akita/har_logger/har_utils.rb
+++ b/lib/akita/har_logger/har_utils.rb
@@ -9,15 +9,26 @@ module Akita
       # If we are unable to do this reinterpretation, return the string
       # unchanged, but log a warning that points to the caller.
       def self.fixEncoding(v)
-        if v != nil && v.encoding == Encoding::ASCII_8BIT then
-          forced = String.new(v).force_encoding(Encoding::UTF_8)
-          if forced.valid_encoding? then
-            v = forced
-          else
-            Rails.logger.warn "[#{caller_locations(1, 1)}] Unable to fix encoding: not a valid UTF-8 string. This will likely cause JSON serialization to fail."
-          end
+        if v == nil then
+          return v
         end
 
+        if !(v.is_a? String) then
+          Rails.logger.warn "[#{caller_locations(1, 1)}] fixEncoding was not given a string. This might cause JSON serialization to fail."
+          return v
+        end
+
+        # Only re-interpret 8-bit ASCII.
+        if v.encoding != Encoding::ASCII_8BIT then
+          return v
+        end
+
+        forced = String.new(v).force_encoding(Encoding::UTF_8)
+        if forced.valid_encoding? then
+          return forced
+        end
+
+        Rails.logger.warn "[#{caller_locations(1, 1)}] Unable to fix encoding: not a valid UTF-8 string. This will likely cause JSON serialization to fail."
         v
       end
 

--- a/lib/akita/har_logger/http_request.rb
+++ b/lib/akita/har_logger/http_request.rb
@@ -85,7 +85,7 @@ module Akita
           return Encoding::ISO_8859_1
         end
 
-        Encoding::ASCII_8BIT
+        Encoding::UTF_8
       end
 
       # Obtains the posted data from an HTTP environment.

--- a/lib/akita/har_logger/version.rb
+++ b/lib/akita/har_logger/version.rb
@@ -2,6 +2,6 @@
 
 module Akita
   module HarLogger
-    VERSION = "0.2.5"
+    VERSION = "0.2.6"
   end
 end


### PR DESCRIPTION
If a response body has binary data, ignore the body but record its length. A response body is considered to have binary data if it has an invalid source encoding (other than 8-bit ASCII) or if it cannot be represented in UTF-8.

Fix: Don't assume `fixEncoding` is given a string. If it is given a non-string, log a warning and return the argument unchanged.

Assume UTF-8 by default for request bodies.

Bump to v0.2.6.