### PR TITLE
Convert all headers (and cookies, and parameters) to strings.

### DIFF
--- a/lib/akita/har_logger/har_utils.rb
+++ b/lib/akita/har_logger/har_utils.rb
@@ -39,7 +39,7 @@ module Akita
         hash.reduce([]) { |accum, (k, v)|
           accum.append({
             name: fixEncoding(k),
-            value: fixEncoding(v),
+            value: fixEncoding(v.to_s),
           })
         }
       end

--- a/lib/akita/har_logger/http_request.rb
+++ b/lib/akita/har_logger/http_request.rb
@@ -163,7 +163,7 @@ module Akita
         # for the CRLF on the blank line.
         getHeaders(env).reduce(line_length + 2) { |accum, entry|
           # Header-Name: header value<CR><LF>
-          accum + entry[:name].length + 2 + entry[:value].to_s.length + 2
+          accum + entry[:name].length + 2 + entry[:value].length + 2
         }
       end
 

--- a/lib/akita/har_logger/version.rb
+++ b/lib/akita/har_logger/version.rb
@@ -2,6 +2,6 @@
 
 module Akita
   module HarLogger
-    VERSION = "0.2.7"
+    VERSION = "0.2.8"
   end
 end


### PR DESCRIPTION
Remove redundant .to_s now that conversion is done earlier.