### PR TITLE
Work around non-Rack-compliant middleware

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    akita-har_logger (0.2.9)
+    akita-har_logger (0.2.10)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/akita/har_logger/http_request.rb
+++ b/lib/akita/har_logger/http_request.rb
@@ -122,7 +122,7 @@ module Akita
             # encoding and characters that have no UTF-8 representation by
             # replacing with '?'. Log a warning when this happens.
             sourceCharset = getPostDataCharSet(env)
-            source = String.new(req.body.string).force_encoding(sourceCharset)
+            source = String.new(req.body.read).force_encoding(sourceCharset)
             utf8EncodingSuccessful = false
             if source.valid_encoding? then
               begin

--- a/lib/akita/har_logger/version.rb
+++ b/lib/akita/har_logger/version.rb
@@ -2,6 +2,6 @@
 
 module Akita
   module HarLogger
-    VERSION = "0.2.9"
+    VERSION = "0.2.10"
   end
 end


### PR DESCRIPTION
Some middleware is not Rack-compliant and closes the request input stream, even though the spec says not to: https://github.com/rack/rack/blob/3e74ada113aa7247571e51f0944c65a89e16828b/SPEC.rdoc#the-input-stream-. Work around this by copying the contents of the request input stream before calling down the middleware stack, and then swapping the copy into the Rack environment before calling into the core of `HarLogger`.

Also fixed the core of `HarLogger` to not assume that the request input stream is a `StringIO`.

Bump to v0.2.10.