### PR TITLE
Address issues with response bodies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    akita-har_logger (0.2.10)
+    akita-har_logger (0.2.11)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/akita/har_logger.rb
+++ b/lib/akita/har_logger.rb
@@ -52,6 +52,9 @@ module Akita
         saved_input = env['rack.input']
         env['rack.input'] = StringIO.new request_body
 
+        # Buffer the response body in case it's not a rewindable stream.
+        body = HarLogger.bufferBody(body)
+
         @entry_queue << (HarEntry.new start_time, wait_time_ms, env, status,
                                       headers, body)
 
@@ -60,6 +63,13 @@ module Akita
 
         [ status, headers, body ]
       end
+    end
+
+    # Reads the given body into an array and returns the result.
+    def self.bufferBody(body)
+      result = []
+      body.each { |part| result << part }
+      result
     end
 
     # Logging filter for `ActionController`s.

--- a/lib/akita/har_logger/http_response.rb
+++ b/lib/akita/har_logger/http_response.rb
@@ -159,7 +159,9 @@ module Akita
 
       def getBodySize(body)
         length = 0
-        body.each { |part| length += part.bytesize }
+        # Convert each body part into a string in case we're dealing with
+        # non-Rack-compliant components.
+        body.each { |part| length += part.to_s.bytesize }
         length
       end
     end

--- a/lib/akita/har_logger/version.rb
+++ b/lib/akita/har_logger/version.rb
@@ -2,6 +2,6 @@
 
 module Akita
   module HarLogger
-    VERSION = "0.2.10"
+    VERSION = "0.2.11"
   end
 end


### PR DESCRIPTION
Buffer response bodies in case they are coming from a non-rewindable stream. The [Rack specification](https://github.com/rack/rack/blob/d15dd728440710cfc35ed155d66a98dc2c07ae42/SPEC.rdoc#the-body-) says we can't count on being able to call `each` on the body more than once.

When computing the response body size, convert each part into a string, in case we're dealing with non-Rack-compliant components. (The Rack specification says `each` must only yield String values.)

Bumped to v0.2.11.