### PR TITLE
Fix recursive locking when running with `config.allow_concurrency = false`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    akita-har_logger (0.2.13)
+    akita-har_logger (0.2.14)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/akita/har_logger.rb
+++ b/lib/akita/har_logger.rb
@@ -55,9 +55,6 @@ module Akita
         saved_input = env['rack.input']
         env['rack.input'] = StringIO.new request_body
 
-        # Buffer the response body in case it's not a rewindable stream.
-        body = HarLogger.bufferBody(body)
-
         @entry_queue << (HarEntry.new start_time, wait_time_ms, env, status,
                                       headers, body)
 
@@ -74,17 +71,10 @@ module Akita
     # Logs the given exception.
     def self.logException(context, e)
       Rails.logger.debug "AKITA: Exception while #{context}: #{e.message} "\
-                         "(#{e.class.name})"
+                         "(#{e.class.name}) in thread #{Thread.current}"
       e.backtrace.each { |frame|
         Rails.logger.debug "AKITA:   #{frame}"
       }
-    end
-
-    # Reads the given body into an array and returns the result.
-    def self.bufferBody(body)
-      result = []
-      body.each { |part| result << part }
-      result
     end
 
     # Logging filter for `ActionController`s.

--- a/lib/akita/har_logger/version.rb
+++ b/lib/akita/har_logger/version.rb
@@ -2,6 +2,6 @@
 
 module Akita
   module HarLogger
-    VERSION = "0.2.13"
+    VERSION = "0.2.14"
   end
 end


### PR DESCRIPTION
Apparently, the buffering of the response body introduced in #14 causes Rack to fail with a recursive-lock exception when running with `config.allow_concurrency = false`. Unclear why this happens.

This reverts the buffering of the response body, though we now appear to be doing precisely what the Rack specification advises against: "Middleware must not call `each` directly on the Body. Instead, middleware can return a new Body that calls `each` on the original Body, yielding at least once per iteration." (https://github.com/rack/rack/blob/d15dd728440710cfc35ed155d66a98dc2c07ae42/SPEC.rdoc#the-body-)

Bumped to 0.2.14.